### PR TITLE
当找不到文件时，不抛出异常堆栈

### DIFF
--- a/common/style/style.go
+++ b/common/style/style.go
@@ -25,3 +25,13 @@ func InfoPrefix(prefix string) *pterm.PrefixPrinter {
 		MessageStyle: pterm.Info.MessageStyle,
 	}
 }
+
+func ErrorPrefix(prefix string) *pterm.PrefixPrinter {
+	return &pterm.PrefixPrinter{
+		Prefix: pterm.Prefix{
+			Text:  prefix,
+			Style: pterm.Error.Prefix.Style,
+		},
+		MessageStyle: pterm.Error.MessageStyle,
+	}
+}

--- a/v1/cmd/deploy/deploy.go
+++ b/v1/cmd/deploy/deploy.go
@@ -20,6 +20,7 @@ package deploy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/koupleless/arkctl/common/osutil"
 	"os"
@@ -169,6 +170,10 @@ func execParseBizModel(ctx *contextutil.Context) bool {
 	}
 
 	bizModel, err := ark.ParseBizModel(ctx, fileutil.FileUrl(bundlePath))
+	if errors.Is(err, os.ErrNotExist) {
+		style.ErrorPrefix("File Not Exist").Println(defaultArg)
+		return false
+	}
 	if err != nil {
 		pterm.Error.PrintOnError(fmt.Errorf("failed to parse bundle: %s", err))
 		return false

--- a/v1/service/ark/biz_util.go
+++ b/v1/service/ark/biz_util.go
@@ -17,9 +17,11 @@ package ark
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"github.com/koupleless/arkctl/common/osutil"
 	"github.com/koupleless/arkctl/common/runtime"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/koupleless/arkctl/common/fileutil"
@@ -36,8 +38,11 @@ func parseJarBizModel(ctx context.Context, bizUrl fileutil.FileUrl) (model *BizM
 	defer runtime.RecoverFromError(&err)
 	fileUtil := fileutil.DefaultFileUtil()
 	localPath := runtime.MustReturnResult(fileUtil.Download(ctx, bizUrl))
-
-	zipReader := runtime.MustReturnResult(zip.OpenReader(localPath[len(osutil.GetLocalFileProtocol()):]))
+	readerJar, err := zip.OpenReader(localPath[len(osutil.GetLocalFileProtocol()):])
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	zipReader := runtime.MustReturnResult(readerJar, err)
 	defer zipReader.Close()
 
 	bizName := ""

--- a/v1/service/ark/biz_util_test.go
+++ b/v1/service/ark/biz_util_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/koupleless/arkctl/common/osutil"
+	assert2 "github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
@@ -30,6 +31,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/magiconair/properties/assert"
 )
+
+func TestParseBizModel_FileNotExist(t *testing.T) {
+	_, err := ParseBizModel(
+		context.Background(),
+		"file://ll.jar",
+	)
+	assert2.ErrorIs(t, err, os.ErrNotExist)
+}
 
 func TestParseBizModel_LocalJar(t *testing.T) {
 	// creating a mock jar file


### PR DESCRIPTION
当找不到文件时，不抛出异常堆栈
fix koupleless/koupleless/issues/158