### PR TITLE
feat: 添加不输入任何指令回车输出help内容

### DIFF
--- a/v1/cmd/root/root.go
+++ b/v1/cmd/root/root.go
@@ -32,6 +32,10 @@ var cfgFile string
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			cobra.CheckErr(cmd.Help())
+			os.Exit(1)
+		}
 	},
 }
 


### PR DESCRIPTION
当前arkctl不输入任何指令回车仅输出welcome文字，
添加不输入任何指令回车输出help内容的功能
修改前效果:
<img width="481" alt="image" src="https://github.com/koupleless/arkctl/assets/41184355/36d81ff1-f009-4189-a394-c603524553d3">
修改后效果:
<img width="619" alt="image" src="https://github.com/koupleless/arkctl/assets/41184355/9c512d76-65d3-4095-a50b-18b2d66136b7">
