### PR TITLE
fix: arkctl version to 0.2.3

### DIFF
--- a/v1/constant/constant.go
+++ b/v1/constant/constant.go
@@ -18,5 +18,5 @@
 package constant
 
 const (
-	Version = "0.2.1"
+	Version = "0.2.3"
 )


### PR DESCRIPTION

fix issue https://github.com/koupleless/koupleless/issues/393 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 0.2.3, marking the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->