### PR TITLE
feat(deploy): 添加自定义 Maven 命令功能

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.3
 
 require (
 	github.com/go-resty/resty/v2 v2.11.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.4.0
 	github.com/magiconair/properties v1.8.5
 	github.com/manifoldco/promptui v0.9.0
@@ -15,6 +16,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.23.0
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -44,7 +46,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/v1/cmd/deploy/deploy.go
+++ b/v1/cmd/deploy/deploy.go
@@ -122,9 +122,11 @@ func execMavenBuild(ctx *contextutil.Context) bool {
 	compileArg := []string{"clean", "package", "-Dmaven.test.skip=true"}
 	if mvnCmd != "" {
 		// custom maven command
-		args := append(compileArg, strings.Split(mvnCmd, " ")...)
-		compileCmd = args[0]
-		compileArg = args[1:]
+		args := strings.Split(mvnCmd, " ")
+		if len(args) > 0 {
+			compileCmd = args[0]
+			compileArg = args[1:]
+		}
 	}
 
 	mvn := cmdutil.BuildCommandWithWorkDir(

--- a/v1/cmd/deploy/deploy.go
+++ b/v1/cmd/deploy/deploy.go
@@ -479,6 +479,7 @@ If Provided, arkctl will try to deploy the bundle to the ark container running i
 If provided, overrides the Maven invocation for building. Example: "mvn -q -T1C" or "./mvnw clean package".
 Tokens are split by whitespace (strings.Fields); shell-style quoting is not supported via this single flag.
 When empty, defaults to: mvn `+strings.Join(defaultMavenArgs, " ")+`.
+Note: providing any non-empty value replaces the default arguments entirely. Supplying just "mvn" or "mvnw" yields no default goals.
 `)
 
 	DeployCommand.Flags().StringVar(&subBundlePath, "sub", "", `

--- a/v1/cmd/deploy/deploy.go
+++ b/v1/cmd/deploy/deploy.go
@@ -53,6 +53,10 @@ var (
 	podName      string // pre parsed pod name
 
 	mvnCmd string //custom maven command
+
+	// default maven compile command and args, centralized to avoid drift with tests
+	defaultMavenCmd  = "mvn"
+	defaultMavenArgs = []string{"clean", "package", "-Dmaven.test.skip=true"}
 )
 
 const (
@@ -159,8 +163,8 @@ func execMavenBuild(ctx *contextutil.Context) bool {
 }
 
 func parseMavenCommand(mvnCmd string) (string, []string) {
-	compileCmd := "mvn"
-	compileArg := []string{"clean", "package", "-Dmaven.test.skip=true"}
+	compileCmd := defaultMavenCmd
+	compileArg := append([]string(nil), defaultMavenArgs...)
 	if mvnCmd != "" {
 		args := strings.Fields(mvnCmd)
 		if len(args) > 0 {
@@ -472,7 +476,9 @@ If Provided, arkctl will try to deploy the bundle to the ark container running i
 `)
 
 	DeployCommand.Flags().StringVar(&mvnCmd, "mvnCmd", "", `
-If Provided, arkctl will try to deploy the mvnCmd to compile maven project.
+If provided, overrides the Maven invocation for building. Example: "mvn -q -T1C" or "./mvnw clean package".
+Tokens are split by whitespace (strings.Fields); shell-style quoting is not supported via this single flag.
+When empty, defaults to: mvn `+strings.Join(defaultMavenArgs, " ")+`.
 `)
 
 	DeployCommand.Flags().StringVar(&subBundlePath, "sub", "", `

--- a/v1/cmd/deploy/deploy.go
+++ b/v1/cmd/deploy/deploy.go
@@ -118,16 +118,7 @@ func execMavenBuild(ctx *contextutil.Context) bool {
 	style.InfoPrefix("Stage").Println("BuildBundle")
 	style.InfoPrefix("BuildDirectory").Println(defaultArg)
 
-	compileCmd := "mvn"
-	compileArg := []string{"clean", "package", "-Dmaven.test.skip=true"}
-	if mvnCmd != "" {
-		// custom maven command
-		args := strings.Split(mvnCmd, " ")
-		if len(args) > 0 {
-			compileCmd = args[0]
-			compileArg = args[1:]
-		}
-	}
+	compileCmd, compileArg := parseMavenCommand(mvnCmd)
 
 	mvn := cmdutil.BuildCommandWithWorkDir(
 		ctx,
@@ -165,6 +156,19 @@ func execMavenBuild(ctx *contextutil.Context) bool {
 	pterm.Info.Printfln(pterm.Green("build bundle success!"))
 	pterm.Println()
 	return true
+}
+
+func parseMavenCommand(mvnCmd string) (string, []string) {
+	compileCmd := "mvn"
+	compileArg := []string{"clean", "package", "-Dmaven.test.skip=true"}
+	if mvnCmd != "" {
+		args := strings.Fields(mvnCmd)
+		if len(args) > 0 {
+			compileCmd = args[0]
+			compileArg = args[1:]
+		}
+	}
+	return compileCmd, compileArg
 }
 
 func execParseBizModel(ctx *contextutil.Context) bool {

--- a/v1/cmd/deploy/deploy_test.go
+++ b/v1/cmd/deploy/deploy_test.go
@@ -1,0 +1,71 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package deploy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMavenCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		mvnCmd   string
+		wantCmd  string
+		wantArgs []string
+	}{
+		{
+			name:     "empty command",
+			mvnCmd:   "",
+			wantCmd:  "mvn",
+			wantArgs: []string{"clean", "package", "-Dmaven.test.skip=true"},
+		},
+		{
+			name:     "custom command without args",
+			mvnCmd:   "mvnw",
+			wantCmd:  "mvnw",
+			wantArgs: []string{},
+		},
+		{
+			name:     "custom command with args",
+			mvnCmd:   "mvn clean install",
+			wantCmd:  "mvn",
+			wantArgs: []string{"clean", "install"},
+		},
+		{
+			name:     "complex command with args",
+			mvnCmd:   "mvnw clean package -DskipTests",
+			wantCmd:  "mvnw",
+			wantArgs: []string{"clean", "package", "-DskipTests"},
+		},
+		{
+			name:     "command with multiple spaces",
+			mvnCmd:   "mvn    clean    package",
+			wantCmd:  "mvn",
+			wantArgs: []string{"clean", "package"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArgs := parseMavenCommand(tt.mvnCmd)
+			if gotCmd != tt.wantCmd {
+				t.Errorf("parseMavenCommand() gotCmd = %v, want %v", gotCmd, tt.wantCmd)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("parseMavenCommand() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/v1/cmd/deploy/deploy_test.go
+++ b/v1/cmd/deploy/deploy_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseMavenCommand(t *testing.T) {
@@ -102,6 +103,24 @@ func TestParseMavenCommand(t *testing.T) {
 			wantCmd:  "mvn",
 			wantArgs: []string{"-DskipTests=true", "-Pprod"},
 		},
+		{
+			name:     "thread-count with separate value",
+			mvnCmd:   "mvn -T 1C",
+			wantCmd:  "mvn",
+			wantArgs: []string{"-T", "1C"},
+		},
+		{
+			name:     "multiple profiles in one flag",
+			mvnCmd:   "mvn -Pprod,dev",
+			wantCmd:  "mvn",
+			wantArgs: []string{"-Pprod,dev"},
+		},
+		{
+			name:     "reactor and project list",
+			mvnCmd:   "mvn -am -pl :module",
+			wantCmd:  "mvn",
+			wantArgs: []string{"-am", "-pl", ":module"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -112,7 +131,7 @@ func TestParseMavenCommand(t *testing.T) {
 			if gotCmd != tt.wantCmd {
 				t.Errorf("parseMavenCommand() gotCmd = %q, want %q", gotCmd, tt.wantCmd)
 			}
-			if diff := cmp.Diff(tt.wantArgs, gotArgs); diff != "" {
+			if diff := cmp.Diff(tt.wantArgs, gotArgs, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("parseMavenCommand() args mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/v1/cmd/deploy/deploy_test.go
+++ b/v1/cmd/deploy/deploy_test.go
@@ -14,11 +14,16 @@
 package deploy
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseMavenCommand(t *testing.T) {
+	t.Parallel()
+
+	defaultArgs := append([]string(nil), defaultMavenArgs...)
+
 	tests := []struct {
 		name     string
 		mvnCmd   string
@@ -28,8 +33,8 @@ func TestParseMavenCommand(t *testing.T) {
 		{
 			name:     "empty command",
 			mvnCmd:   "",
-			wantCmd:  "mvn",
-			wantArgs: []string{"clean", "package", "-Dmaven.test.skip=true"},
+			wantCmd:  defaultMavenCmd,
+			wantArgs: defaultArgs,
 		},
 		{
 			name:     "custom command without args",
@@ -55,16 +60,60 @@ func TestParseMavenCommand(t *testing.T) {
 			wantCmd:  "mvn",
 			wantArgs: []string{"clean", "package"},
 		},
+		{
+			name:     "whitespace-only command",
+			mvnCmd:   " \t\n ",
+			wantCmd:  defaultMavenCmd,
+			wantArgs: defaultArgs,
+		},
+		{
+			name:     "leading and trailing spaces",
+			mvnCmd:   "   mvn clean package   ",
+			wantCmd:  "mvn",
+			wantArgs: []string{"clean", "package"},
+		},
+		{
+			name:     "tabs between tokens",
+			mvnCmd:   "mvn\tclean\tinstall",
+			wantCmd:  "mvn",
+			wantArgs: []string{"clean", "install"},
+		},
+		{
+			name:     "windows wrapper with flags",
+			mvnCmd:   "mvnw.cmd -q -T1C",
+			wantCmd:  "mvnw.cmd",
+			wantArgs: []string{"-q", "-T1C"},
+		},
+		{
+			name:     "absolute path mvn",
+			mvnCmd:   "/usr/local/bin/mvn -q",
+			wantCmd:  "/usr/local/bin/mvn",
+			wantArgs: []string{"-q"},
+		},
+		{
+			name:     "relative path wrapper",
+			mvnCmd:   "./mvnw -q",
+			wantCmd:  "./mvnw",
+			wantArgs: []string{"-q"},
+		},
+		{
+			name:     "args with equals and profile",
+			mvnCmd:   "mvn -DskipTests=true -Pprod",
+			wantCmd:  "mvn",
+			wantArgs: []string{"-DskipTests=true", "-Pprod"},
+		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotCmd, gotArgs := parseMavenCommand(tt.mvnCmd)
 			if gotCmd != tt.wantCmd {
-				t.Errorf("parseMavenCommand() gotCmd = %v, want %v", gotCmd, tt.wantCmd)
+				t.Errorf("parseMavenCommand() gotCmd = %q, want %q", gotCmd, tt.wantCmd)
 			}
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
-				t.Errorf("parseMavenCommand() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
+			if diff := cmp.Diff(tt.wantArgs, gotArgs); diff != "" {
+				t.Errorf("parseMavenCommand() args mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
- 新增 mvnCmd 字符串变量，用于存储自定义 Maven 命令
- 在帮助文档中添加 Scenario 1，说明如何使用自定义 Maven 命令进行构建和部署
- 修改 execMavenBuild 函数，支持使用自定义 Maven 命令
- 在 init 函数中添加 mvnCmd 的命令行参数定义
- [fix](https://github.com/koupleless/koupleless/issues/414)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom Maven command when deploying via a new CLI option.
* **Documentation**
  * Updated help text and usage examples to show how to build with a custom Maven command and revised example scenarios.
* **Tests**
  * Added unit tests validating parsing of custom Maven command strings and argument handling across edge cases.
* **Chores**
  * Updated project dependencies to support the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->