### PR TITLE
fix 模块 pod 替换导致 JVM 进程内模块实例消失

### DIFF
--- a/v1/cmd/undeploy/undeploy.go
+++ b/v1/cmd/undeploy/undeploy.go
@@ -32,6 +32,7 @@ var (
 	hostFlag          string = "127.0.0.1"
 	portFlag          int
 	bizNameAndVersion string // in the format of bizName:bizVersion
+	bizModelVersionFlag   string // biz model version, used to identify the biz model in the pod
 )
 
 var (
@@ -78,6 +79,7 @@ func execUnInstallLocal(ctx *contextutil.Context) error {
 		BizModel: ark.BizModel{
 			BizName:    strings.Split(bizNameAndVersion, ":")[0],
 			BizVersion: strings.Split(bizNameAndVersion, ":")[1],
+			BizModelVersion: bizModelVersionFlag,
 		},
 	}); err != nil {
 		pterm.Error.Printfln("uninstall %s failed: %s", bizNameAndVersion, err)
@@ -130,6 +132,7 @@ func execUnInstallLocalWithPrompt(ctx *contextutil.Context) error {
 
 func init() {
 	UnDeployCmd.Flags().IntVar(&portFlag, "port", 1238, "the port of ark container")
+	UnDeployCmd.Flags().StringVar(&bizModelVersionFlag, "biz-model-version", "", "the biz model version of ark container")
 
 	root.RootCmd.AddCommand(UnDeployCmd)
 }

--- a/v1/service/ark/types.go
+++ b/v1/service/ark/types.go
@@ -107,6 +107,9 @@ type BizModel struct {
 
 	// BizUrl is the location of source code.
 	BizUrl fileutil.FileUrl `json:"bizUrl,omitempty"`
+
+	// BizModelVersion is the version of this model.
+	BizModelVersion string `json:"bizModelVersion,omitempty"`
 }
 
 type BizInfo struct {


### PR DESCRIPTION
https://github.com/koupleless/koupleless/issues/405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --biz-model-version flag to deploy and undeploy commands to specify the business model version used during installation and uninstallation, including in Kubernetes environments.
- Documentation
  - Updated command help and examples to show deployment and undeployment with a specified biz model version.
- Chores
  - Bumped version to 0.2.5.
  - Minor formatting adjustment to a flag description (no behavior change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->